### PR TITLE
Implements issue #5, Ability to add items to layout/tag by name (search).

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
@@ -4,6 +4,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("banktaglayouts")
 public interface BankTagLayoutsConfig extends Config {
@@ -158,5 +159,16 @@ public interface BankTagLayoutsConfig extends Config {
 	)
 	default boolean showCoreRuneliteLayoutOptions() {
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "addKeybind",
+		name = "Add item keybind",
+		description = "Keyboard shortcut for adding a placeholder",
+		position = 11
+	)
+	default Keybind addKeybind()
+	{
+		return Keybind.NOT_SET;
 	}
 }


### PR DESCRIPTION
I've implemented the ability to add an item to the layout via search. #5
https://www.youtube.com/watch?v=E01dj89zxzg

Have a look if you think this implementation is sufficient.
Could use a code review as it's my first contribution to your project, but it seems to be working great!

Definitely something I was looking for on my group iron.


When adding a bunch of items a keybind for this action would be nice too.

Maybe it'd be nice to add the item on the first visible index, when adding items to a long tab you have to scroll up and drag it over to where you where trying to add something