### PR TITLE
Fix potion storage issue

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -116,6 +116,7 @@ import net.runelite.client.util.Text;
 public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 {
 	public static final IntPredicate FILTERED_CHARS = c -> "</>:".indexOf(c) == -1;
+	public static final int POTIONS_BANK_TAB_VARBIT = 15;
 
 	public static final Color itemTooltipColor = new Color(0xFF9040);
 
@@ -617,6 +618,12 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 	private String inventorySetup = null;
 	private void updateInventorySetupShown() {
+		// Disable inventory setup when in potions tab.
+		if(client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == POTIONS_BANK_TAB_VARBIT)
+		{
+			inventorySetup = null;
+			return;
+		}
 		Widget bankTitleBar = client.getWidget(ComponentID.BANK_TITLE_BAR);
 		String newSetup = null;
 		if (bankTitleBar != null)
@@ -878,10 +885,6 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 		LayoutableThing layoutable = getCurrentLayoutableThing();
 		if (layoutable == null) {
-			return;
-		}
-
-		if (client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == 15) {
 			return;
 		}
 

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -116,7 +116,6 @@ import net.runelite.client.util.Text;
 public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 {
 	public static final IntPredicate FILTERED_CHARS = c -> "</>:".indexOf(c) == -1;
-	public static final int POTIONS_BANK_TAB_VARBIT = 15;
 
 	public static final Color itemTooltipColor = new Color(0xFF9040);
 
@@ -618,12 +617,11 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 	private String inventorySetup = null;
 	private void updateInventorySetupShown() {
-		// Disable inventory setup when in potions tab.
-		if(client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == POTIONS_BANK_TAB_VARBIT)
-		{
+		if (client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == 15 /* potion storage */) {
 			inventorySetup = null;
 			return;
 		}
+
 		Widget bankTitleBar = client.getWidget(ComponentID.BANK_TITLE_BAR);
 		String newSetup = null;
 		if (bankTitleBar != null)

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -881,6 +881,10 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 			return;
 		}
 
+		if (client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == 15) {
+			return;
+		}
+
 		log.debug("applyCustomBankTagItemPositions: " + layoutable);
 
 		indexToWidget.clear();


### PR DESCRIPTION
This fixes an issue where potion storage cannot be interacted with then there is an active Bank Tag Layout enabled.

I'm hoping this is a valid approach to this, but open to suggestions. Essentially what happens without this change is that the layout is still enabled behind the scenes, and seems to be overriding the interactions with the potion storage. Notice how the right-click menu contains the item in my inventory setup at that location. And for some reason, if you're hovering over that area, clicking to withdraw a potion just doesn't do anything, the click is effectively inert. If you move your mouse so it's not over that area, you're able to interact.

![image](https://github.com/user-attachments/assets/6c47af0d-e4ce-404c-8337-012559352695)

The way i approached this is just to return early if the potion storage tab (tab 15) is currently selected