### PR TITLE
Auto Layout Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.34'
+def runeLiteVersion = '1.10.40'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
@@ -150,6 +150,17 @@ public interface BankTagLayoutsConfig extends Config {
 	}
 
 	@ConfigItem(
+			keyName = "addVariationsToEnd",
+			name = "Add Variations to End",
+			description = "Enabling this will add variations to the end of your layout instead of the front.",
+			position = 6,
+			section = autoLayout
+	)
+	default boolean addVariationsToEnd() {
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showCoreRuneliteLayoutOptions",
 		name = "RuneLite layouts options",
 		description = "Shows RuneLite's layout options at the same time as bank tag layouts, e.g. on the tag tab right-click menu.",

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
@@ -150,13 +150,13 @@ public interface BankTagLayoutsConfig extends Config {
 	}
 
 	@ConfigItem(
-			keyName = "addVariationsToEnd",
-			name = "Add Variations to End",
-			description = "Enabling this will add variations to the end of your layout instead of the front.",
+			keyName = "addNewItemsToEnd",
+			name = "Add New Items to End",
+			description = "Enabling this will add new items and variations to the end of your layout instead of the beginning.",
 			position = 6,
 			section = autoLayout
 	)
-	default boolean addVariationsToEnd() {
+	default boolean addNewItemsToEnd() {
 		return false;
 	}
 

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -1073,7 +1073,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 				if (indexForItem == -1) {
 					// The item is not in the layout.
-					indexForItem = config.addVariationsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
+					indexForItem = config.addNewItemsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
 					layout.putItem(itemId, indexForItem);
 				}
 				indexToWidget.put(indexForItem, bankItem);
@@ -1565,7 +1565,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 					int itemId = notYetPositionedWidget.getItemId();
 					int layoutIndex = layout.getIndexForItem(itemId);
 					if (layoutIndex != -1) continue; // Prevents an issue where items with the same id that take up multiple bank slots, e.g. items that have their charges stored on the item, can be added into two slots during this stage.
-					int index = config.addVariationsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
+					int index = config.addNewItemsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
 					layout.putItem(itemId, index);
 					log.debug("item " + itemNameWithId(itemId) + " assigned on pass 4 (assign to empty spot) to index " + index);
 					indexToWidget.put(index, notYetPositionedWidget);

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -1537,6 +1537,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 			}
 		}
 
+		int afterIndex = config.addNewItemsToEnd() ? (layout.getFirstEmptyRow() - 1) : -1;
 		for (Integer variationBaseId : variantItemsInBank.keySet()) {
 			List<Widget> notYetPositionedWidgets = new ArrayList<>(variantItemsInBank.get(variationBaseId));
 
@@ -1565,7 +1566,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 					int itemId = notYetPositionedWidget.getItemId();
 					int layoutIndex = layout.getIndexForItem(itemId);
 					if (layoutIndex != -1) continue; // Prevents an issue where items with the same id that take up multiple bank slots, e.g. items that have their charges stored on the item, can be added into two slots during this stage.
-					int index = config.addNewItemsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
+					int index = layout.getFirstEmptyIndex(afterIndex);
 					layout.putItem(itemId, index);
 					log.debug("item " + itemNameWithId(itemId) + " assigned on pass 4 (assign to empty spot) to index " + index);
 					indexToWidget.put(index, notYetPositionedWidget);

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -131,6 +131,11 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 	public static final String EXPORT_LAYOUT = "Export tag tab with layout";
 	public static final String REMOVE_FROM_LAYOUT_MENU_OPTION = "Remove-layout";
 	public static final String PREVIEW_AUTO_LAYOUT = "Preview auto layout";
+	public static final String SET_ZIGZAG = "Set zigzag";
+	public static final String SET_ZIGZAG_INVASIVE = "Set zigzag (Fresh)";
+	public static final String SET_PRESETS = "Set presets";
+	public static final String SET_PRESETS_INVASIVE = "Set presets (Fresh)";
+	public static final String RESET_LAYOUT = "Reset Layout";
 	public static final String DUPLICATE_ITEM = "Duplicate-item";
 	public static final String REMOVE_DUPLICATE_ITEM = "Remove-duplicate-item";
 
@@ -193,10 +198,38 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 			showLayoutPreviewButton.setOriginalY(45);
 			showLayoutPreviewButton.setSpriteId(Sprites.AUTO_LAYOUT.getSpriteId());
 
-			showLayoutPreviewButton.setOnOpListener((JavaScriptCallback) (e) -> showLayoutPreview());
+			showLayoutPreviewButton.setOnOpListener((JavaScriptCallback) (e) ->
+					{
+						//action index + 1 = op
+						int op = e.getOp();
+						if (op == 1)
+						{
+							showLayoutPreview(BankTagLayoutsConfig.LayoutStyles.ZIGZAG, false);
+						}
+						else if (op == 2)
+						{
+							showLayoutPreview(BankTagLayoutsConfig.LayoutStyles.ZIGZAG, true);
+						}
+						if (op == 3)
+						{
+							showLayoutPreview(BankTagLayoutsConfig.LayoutStyles.PRESETS, false);
+						}
+						else if (op == 4)
+						{
+							showLayoutPreview(BankTagLayoutsConfig.LayoutStyles.PRESETS, true);
+						}
+						else
+						{
+							showLayoutPreview(null, true);
+						}
+					});
 			showLayoutPreviewButton.setHasListener(true);
 			showLayoutPreviewButton.revalidate();
-			showLayoutPreviewButton.setAction(0, PREVIEW_AUTO_LAYOUT);
+			showLayoutPreviewButton.setAction(0, SET_ZIGZAG);
+			showLayoutPreviewButton.setAction(1, SET_ZIGZAG_INVASIVE);
+			showLayoutPreviewButton.setAction(2, SET_PRESETS);
+			showLayoutPreviewButton.setAction(3, SET_PRESETS_INVASIVE);
+			showLayoutPreviewButton.setAction(4, RESET_LAYOUT);
 
 			applyLayoutPreviewButton = parent.createChild(-1, WidgetType.GRAPHIC);
 
@@ -491,7 +524,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 	private final InventorySetupsAdapter inventorySetupsAdapter = new InventorySetupsAdapter(this);
 
-	private void showLayoutPreview() {
+	private void showLayoutPreview(BankTagLayoutsConfig.LayoutStyles styleToUse, boolean invasive) {
 
 		if (isShowingPreview()) return;
 		LayoutableThing currentLayoutableThing = getCurrentLayoutableThing();
@@ -518,14 +551,14 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 			Layout currentLayout = getBankOrderNonPreview(currentLayoutableThing);
 			if (currentLayout == null) currentLayout = Layout.emptyLayout();
 
-			previewLayout = layoutGenerator.basicBankTagLayout(equippedGear, inventory, config.autoLayoutIncludeRunePouchRunes() ? getRunePouchRunes() : Collections.emptyList(), Collections.emptyList(), currentLayout, getAutoLayoutDuplicateLimit(), config.autoLayoutStyle());
+			previewLayout = layoutGenerator.basicBankTagLayout(equippedGear, inventory, config.autoLayoutIncludeRunePouchRunes() ? getRunePouchRunes() : Collections.emptyList(), Collections.emptyList(), invasive ? Layout.emptyLayout() : currentLayout, getAutoLayoutDuplicateLimit(), styleToUse);
 		} else {
 			InventorySetup inventorySetup = inventorySetupsAdapter.getInventorySetup(currentLayoutableThing.name);
 
 			Layout currentLayout = getBankOrderNonPreview(currentLayoutableThing);
 			if (currentLayout == null) currentLayout = Layout.emptyLayout();
 
-			previewLayout = layoutGenerator.basicInventorySetupsLayout(inventorySetup, currentLayout, getAutoLayoutDuplicateLimit(), config.autoLayoutStyle(), config.autoLayoutIncludeRunePouchRunes());
+			previewLayout = layoutGenerator.basicInventorySetupsLayout(inventorySetup, invasive ? Layout.emptyLayout() : currentLayout, getAutoLayoutDuplicateLimit(), styleToUse, config.autoLayoutIncludeRunePouchRunes());
 		}
 
 		hideLayoutPreviewButtons(false);
@@ -1423,7 +1456,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		} else if (IMPORT_LAYOUT.equals(menuOption)) {
 			importLayout();
 		} else if (PREVIEW_AUTO_LAYOUT.equals(menuOption)) {
-			showLayoutPreview();
+			showLayoutPreview(config.autoLayoutStyle(), false);
 		} else if (DUPLICATE_ITEM.equals(menuOption)) {
 			duplicateItem(event.getParam0());
 		} else if (REMOVE_DUPLICATE_ITEM.equals(menuOption)) {
@@ -1909,7 +1942,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		for (MenuEntry entry : menuEntries)
 		{
 			// checking the type is kinda hacky because really both preview auto layout entries should have the runelite id... but it works.
-			if (entry.getOption().equals(PREVIEW_AUTO_LAYOUT) && entry.getType() != MenuAction.RUNELITE)
+			if (entry.getOption().equals(SET_ZIGZAG) && entry.getType() != MenuAction.RUNELITE)
 			{
 				event.setForceRightClick(true);
 				return;

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -1040,7 +1040,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 				if (indexForItem == -1) {
 					// The item is not in the layout.
-					indexForItem = layout.getFirstEmptyIndex();
+					indexForItem = config.addVariationsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
 					layout.putItem(itemId, indexForItem);
 				}
 				indexToWidget.put(indexForItem, bankItem);
@@ -1532,7 +1532,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 					int itemId = notYetPositionedWidget.getItemId();
 					int layoutIndex = layout.getIndexForItem(itemId);
 					if (layoutIndex != -1) continue; // Prevents an issue where items with the same id that take up multiple bank slots, e.g. items that have their charges stored on the item, can be added into two slots during this stage.
-					int index = layout.getFirstEmptyIndex();
+					int index = config.addVariationsToEnd() ? layout.getLastEmptyIndex() : layout.getFirstEmptyIndex();
 					layout.putItem(itemId, index);
 					log.debug("item " + itemNameWithId(itemId) + " assigned on pass 4 (assign to empty spot) to index " + index);
 					indexToWidget.put(index, notYetPositionedWidget);

--- a/src/main/java/com/banktaglayouts/Layout.java
+++ b/src/main/java/com/banktaglayouts/Layout.java
@@ -117,7 +117,15 @@ public class Layout {
 
     public int getLastEmptyIndex() {
         int maxIndex = getAllUsedIndexes().stream().max(Integer::compare).orElse(-1);
-        return getFirstEmptyIndex(maxIndex);
+        return maxIndex + 1;
+    }
+
+    public  int getFirstEmptyRow() {
+        int maxIndex = getAllUsedIndexes().stream().max(Integer::compare).orElse(-1);
+        maxIndex++;
+        while (maxIndex % 8 != 0)
+            maxIndex++;
+        return  maxIndex;
     }
 
     public int getFirstEmptyIndex(int afterThisIndex) {

--- a/src/main/java/com/banktaglayouts/Layout.java
+++ b/src/main/java/com/banktaglayouts/Layout.java
@@ -115,6 +115,11 @@ public class Layout {
         return getFirstEmptyIndex(-1);
     }
 
+    public int getLastEmptyIndex() {
+        int maxIndex = getAllUsedIndexes().stream().max(Integer::compare).orElse(-1);
+        return getFirstEmptyIndex(maxIndex);
+    }
+
     public int getFirstEmptyIndex(int afterThisIndex) {
         List<Integer> indexes = new ArrayList<>(getAllUsedIndexes());
         indexes.sort(Integer::compare);

--- a/src/main/java/com/banktaglayouts/LayoutGenerator.java
+++ b/src/main/java/com/banktaglayouts/LayoutGenerator.java
@@ -31,6 +31,11 @@ public class LayoutGenerator {
 			.map(itemId -> plugin.itemManager.canonicalize(itemId)) // Weight reducing items have different ids when equipped; this fixes that.
 			.collect(Collectors.toList());
 
+		if (layoutStyle == null)
+		{
+			return Layout.emptyLayout();
+		}
+
 		switch (layoutStyle){
 			case ZIGZAG:
 				return zigzagLayout(equippedItems, inventory, runePouch, additionalItems, currentLayout, duplicateLimit);

--- a/src/main/java/com/banktaglayouts/LayoutGenerator.java
+++ b/src/main/java/com/banktaglayouts/LayoutGenerator.java
@@ -28,8 +28,11 @@ public class LayoutGenerator {
 			runePouch = null;
 		}
 		equippedItems = equippedItems.stream()
-			.map(itemId -> plugin.itemManager.canonicalize(itemId)) // Weight reducing items have different ids when equipped; this fixes that.
-			.collect(Collectors.toList());
+				.map(itemId -> plugin.itemManager.canonicalize(itemId)) // Weight reducing items have different ids when equipped; this fixes that.
+				.collect(Collectors.toList());
+		inventory = inventory.stream()
+				.map(itemId -> plugin.itemManager.canonicalize(itemId)) // You can't have noted items in your bank
+				.collect(Collectors.toList());
 
 		if (layoutStyle == null)
 		{

--- a/src/main/java/inventorysetupz/InventorySetupsVariationMapping.java
+++ b/src/main/java/inventorysetupz/InventorySetupsVariationMapping.java
@@ -142,6 +142,10 @@ public class InventorySetupsVariationMapping
 		mappings.put(GHOMMALS_AVERNIC_DEFENDER_5_L, AVERNIC_DEFENDER);
 		mappings.put(GHOMMALS_AVERNIC_DEFENDER_6, AVERNIC_DEFENDER);
 		mappings.put(GHOMMALS_AVERNIC_DEFENDER_6_L, AVERNIC_DEFENDER);
+
+		// Blazing blowpipe -> toxic blowpipe
+		mappings.put(BLAZING_BLOWPIPE_EMPTY, TOXIC_BLOWPIPE_EMPTY);
+		mappings.put(BLAZING_BLOWPIPE, TOXIC_BLOWPIPE);
 	}
 
 }


### PR DESCRIPTION
Adds new functionality:

1) Previously when additional items (new items or variations / fuzzy matches) were being added, they would fill in the first empty space in a layout. Most noticeably when using Inventory Setups with Presets layout this would cause items like potions to pollute the equipment area. There is now a new config option to add variations after the last item.

Before:

<img width="984" alt="before" src="https://github.com/user-attachments/assets/9ac4b903-f54d-471a-a367-a86684f5fd2f">


After:

<img width="1001" alt="after" src="https://github.com/user-attachments/assets/415e9ada-a930-417b-b3a5-728769b6ed96">


2) In addition, there is currently no way to delete/override an existing layout without changing the name of the setup or deleting it from the config. This PR revamps the 'auto layout button' to include new options:

- Set zigzag
- Set zigzag (fresh)
- Set presets
- Set presets (fresh)
- Reset

The 'fresh' options will perform a more invasive auto-layout that will discard the existing layout. The 'reset' option will clear any layout data.

3. Lastly, canonicalizes items in inventory, to prevent noted item placeholders from appearing in the bank.




Closes #75 