### PR TITLE
Allow Potion Storage to work with Bank Tag Layouts Resolves #99

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.34'
+def runeLiteVersion = '1.10.40'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -72,6 +72,7 @@ import net.runelite.api.events.WidgetClosed;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.ItemQuantityMode;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetPositionMode;

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -1254,7 +1254,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		if (index == -1) return;
 		int itemIdAtIndex = layout.getItemAtIndex(index);
 		if(itemIdAtIndex == -1) return;
-		if(potionStorage.count(itemIdAtIndex) <= 0) return;
+		if(!potionStorage.containsAndHasAny(itemIdAtIndex)) return;
 
 		int potStorageIndex = potionStorage.find(itemIdAtIndex);
 		potionStorage.prepareWidgets();

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -70,7 +70,13 @@ import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetClosed;
 import net.runelite.api.events.WidgetLoaded;
-import net.runelite.api.widgets.*;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetPositionMode;
+import net.runelite.api.widgets.WidgetType;
+import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.ConfigProfile;
@@ -901,37 +907,37 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 				.filter(bankItem -> !bankItem.isHidden() && bankItem.getItemId() >= 0)
 				.collect(Collectors.toList());
 
-		Collection<Integer> layoutItemIds = layout.getAllUsedItemIds();
-		for (Integer itemId : layoutItemIds) {
-			if (potionStorage.containsAndHasAny(itemId)) {
-				if(bankItems.stream().anyMatch(bankItem -> bankItem.getItemId() == itemId)){
-					// Second time we've seen this item, so it is already in the bank, no need to add a new one
-					// Just update the quantity.
-					Widget existing = bankItems.stream().filter(bankItem -> bankItem.getItemId() == itemId).findFirst().orElse(null);
-					existing.setItemQuantity(potionStorage.count(itemId));
-				}else{
-					// Re-use hidden bank items since I haven't found a way to create a widget
-					// We re-purpose the first hidden item we find.
-					// After the first pass, there will be an actual item in the bank representing this potion, so we can re-use that.
-					Widget potionWidget = Arrays.stream(bankContainer.getDynamicChildren())
-							.filter(bankItem -> bankItem.isHidden() || bankItem.getItemId() < 0)
-							.collect(Collectors.toList())
-							.stream().findFirst().get();
+        Collection<Integer> layoutItemIds = layout.getAllUsedItemIds();
+        for (Integer itemId : layoutItemIds) {
+            if (potionStorage.containsAndHasAny(itemId)) {
+                if (bankItems.stream().anyMatch(bankItem -> bankItem.getItemId() == itemId)) {
+                    // Second time we've seen this item, so it is already in the bank, no need to add a new one
+                    // Just update the quantity.
+                    Widget existing = bankItems.stream().filter(bankItem -> bankItem.getItemId() == itemId).findFirst().orElse(null);
+                    existing.setItemQuantity(potionStorage.count(itemId));
+                } else {
+                    // Re-use hidden bank items since I haven't found a way to create a widget
+                    // We re-purpose the first hidden item we find.
+                    // After the first pass, there will be an actual item in the bank representing this potion, so we can re-use that.
+                    Widget potionWidget = Arrays.stream(bankContainer.getDynamicChildren())
+                            .filter(bankItem -> bankItem.isHidden() || bankItem.getItemId() < 0)
+                            .collect(Collectors.toList())
+                            .stream().findFirst().get();
 
-					SetupMenuOptionsForPotion(potionWidget);
+                    SetupMenuOptionsForPotion(potionWidget);
 
-					ItemComposition def = client.getItemDefinition(itemId);
-					potionWidget.setItemId(itemId);
-					potionWidget.setItemQuantity(potionStorage.count(itemId));
-					potionWidget.setItemQuantityMode(ItemQuantityMode.STACKABLE);
-					potionWidget.setName("<col=ff9040>" + def.getName() + "</col>");
-					potionWidget.setHidden(false);
-					potionWidget.revalidate();
+                    ItemComposition def = client.getItemDefinition(itemId);
+                    potionWidget.setItemId(itemId);
+                    potionWidget.setItemQuantity(potionStorage.count(itemId));
+                    potionWidget.setItemQuantityMode(ItemQuantityMode.STACKABLE);
+                    potionWidget.setName("<col=ff9040>" + def.getName() + "</col>");
+                    potionWidget.setHidden(false);
+                    potionWidget.revalidate();
 
-					bankItems.add(potionWidget);
-				}
-			}
-		}
+                    bankItems.add(potionWidget);
+                }
+            }
+        }
 
 		if (!hasVanillaOrHubLayoutEnabled(layoutable)) {
 			for (Widget bankItem : bankItems) {
@@ -971,6 +977,8 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		log.debug("saved tag " + layoutable);
 	}
 
+	// Logic for setting up menu options for potion taken from the standard Bank Tags plugin
+	// See here https://github.com/runelite/runelite/blob/242cfa85298023d91bf52536eedc5394dec4a7f9/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java#L337
 	private void SetupMenuOptionsForPotion(Widget potionWidget) {
 		int quantityType = client.getVarbitValue(Varbits.BANK_QUANTITY_TYPE);
 		int requestQty = client.getVarbitValue(Varbits.BANK_REQUESTEDQUANTITY);

--- a/src/main/java/com/banktaglayouts/Potion.java
+++ b/src/main/java/com/banktaglayouts/Potion.java
@@ -1,0 +1,10 @@
+package com.banktaglayouts;
+
+import net.runelite.api.EnumComposition;
+
+class Potion {
+    EnumComposition potionEnum;
+    int itemId;
+    int doses;
+    int withdrawDoses;
+}

--- a/src/main/java/com/banktaglayouts/PotionStorage.java
+++ b/src/main/java/com/banktaglayouts/PotionStorage.java
@@ -1,0 +1,148 @@
+package com.banktaglayouts;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
+import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetClosed;
+import net.runelite.api.widgets.*;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+@Slf4j
+// This is borrowed from the PotionStorage class in the banktags plugin defined here:
+// https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/PotionStorage.java
+// I made a few modifications to make it work with this plugin
+public class PotionStorage {
+    static final int COMPONENTS_PER_POTION = 5;
+    private final Client client;
+    private Potion[] potions;
+    boolean cachePotions;
+    private Set<Integer> potionStoreVars;
+
+    @Setter
+    private PotionStorageCallback onPotionStorageUpdated;
+
+    @Subscribe
+    public void onClientTick(ClientTick event) {
+        if (cachePotions) {
+            log.debug("Rebuilding potions");
+            cachePotions = false;
+            rebuildPotions();
+
+            Widget w = client.getWidget(ComponentID.BANK_POTIONSTORE_CONTENT);
+
+            if (w != null && potionStoreVars == null) {
+                int[] trigger = w.getVarTransmitTrigger();
+                potionStoreVars = new HashSet<>();
+                Arrays.stream(trigger).forEach(potionStoreVars::add);
+            }
+            if(onPotionStorageUpdated != null){
+                onPotionStorageUpdated.run();
+            }
+        }
+    }
+
+    @Subscribe
+    public void onVarbitChanged(VarbitChanged varbitChanged) {
+        boolean isPotionStoreVar = potionStoreVars != null && potionStoreVars.contains(varbitChanged.getVarpId());
+        boolean isPotionStoreTabBeingSelected = varbitChanged.getVarbitId() == Varbits.CURRENT_BANK_TAB && varbitChanged.getValue() == 15;
+        if (isPotionStoreVar || isPotionStoreTabBeingSelected) {
+            cachePotions = true;
+        }
+    }
+
+    private void rebuildPotions() {
+        EnumComposition potionStorePotions = client.getEnum(EnumID.POTIONSTORE_POTIONS);
+        potions = new Potion[potionStorePotions.size()];
+        int potionsIdx = 0;
+        for (int potionEnumId : potionStorePotions.getIntVals()) {
+            EnumComposition potionEnum = client.getEnum(potionEnumId);
+            client.runScript(ScriptID.POTIONSTORE_DOSES, potionEnumId);
+            int doses = client.getIntStack()[0];
+            client.runScript(ScriptID.POTIONSTORE_WITHDRAW_DOSES, potionEnumId);
+            int withdrawDoses = client.getIntStack()[0];
+
+            if (doses > 0 && withdrawDoses > 0) {
+                Potion p = new Potion();
+                p.potionEnum = potionEnum;
+                p.itemId = potionEnum.getIntValue(withdrawDoses);
+                p.doses = doses;
+                p.withdrawDoses = withdrawDoses;
+                potions[potionsIdx] = p;
+            }
+
+            ++potionsIdx;
+        }
+    }
+
+    public int count(int itemId) {
+        if (potions == null) {
+            return 0;
+        }
+
+        for (Potion potion : potions) {
+            if (potion != null && potion.itemId == itemId) {
+                return potion.doses / potion.withdrawDoses;
+            }
+        }
+        return 0;
+    }
+
+    public boolean containsAndHasAny(int itemId){
+        if (potions == null) {
+            return false;
+        }
+
+        for (Potion potion : potions) {
+            if (potion != null && potion.itemId == itemId) {
+                return potion.doses >= potion.withdrawDoses;
+            }
+        }
+        return false;
+    }
+
+    public int find(int itemId) {
+        if (potions == null) {
+            return -1;
+        }
+
+        int potionIdx = 0;
+        for (Potion potion : potions) {
+            ++potionIdx;
+            if (potion != null && potion.itemId == itemId) {
+                return potionIdx - 1;
+            }
+        }
+        return -1;
+    }
+
+    void prepareWidgets()
+    {
+        // if the potion store hasn't been opened yet, the client components won't have been made yet.
+        // they need to exist for the click to work correctly.
+        Widget potStoreContent = client.getWidget(ComponentID.BANK_POTIONSTORE_CONTENT);
+        if (potStoreContent.getChildren() == null)
+        {
+            int childIdx = 0;
+            for (int i = 0; i < potions.length; ++i)
+            {
+                for (int j = 0; j < COMPONENTS_PER_POTION; ++j)
+                {
+                    potStoreContent.createChild(childIdx++, WidgetType.GRAPHIC);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/banktaglayouts/PotionStorageCallback.java
+++ b/src/main/java/com/banktaglayouts/PotionStorageCallback.java
@@ -1,0 +1,6 @@
+package com.banktaglayouts;
+
+@FunctionalInterface
+public interface PotionStorageCallback{
+    void run();
+}


### PR DESCRIPTION
Resolves #99 

The potion cache was borrowed from Adam's implementation. I had initially tried tying this to fake items, but I found better luck with re-purposing other bank items and changing their item ID.

If there is a way to directly create a widget in the bank that would work, but this is also similar to Adam's implementation.

Open to other approaches, but I believe this is working

![java_sSnsoVQHfJ](https://github.com/user-attachments/assets/16e4c2ae-e66e-48ee-8016-f3bf008d2645)

In this example, all of my potions are in storage, clicking any from the setup will withdraw them, and dragging works. You can see that several right-click options work, and the count in the potion storage declines when withdrawing from the setup