### PR TITLE
Disable Inventory Setups Integration

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsConfig.java
@@ -52,10 +52,11 @@ public interface BankTagLayoutsConfig extends Config {
 		keyName = "useWithInventorySetups",
 		name = "Use with Inventory Setups",
 		description = "Allows laying out of filters applied by the Inventory Setups plugin.",
-		position = 6
+		position = 6,
+		hidden = true
 	)
 	default boolean useWithInventorySetups() {
-		return true;
+		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -980,6 +980,11 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 	LayoutableThing getCurrentLayoutableThing() {
 		String activeTag = tabInterface.getActiveTag();
+
+		// This completely disables Inventory Setups integration.
+		// Inventory Setups now uses core Bank Tags.
+		if (activeTag != null && activeTag.startsWith("_invSetup_")) return null;
+
 		boolean isBankTag = activeTag != null && !activeTag.equals("tagtabs");
 		if (!isBankTag && !(inventorySetup != null && config.useWithInventorySetups())) {
 			return null;


### PR DESCRIPTION
Completely disable inventory setups integration. This will be merged at the same time as inventory setups core btl migration.