### PR TITLE
Update tag prefix for inventory setups

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -983,7 +983,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 		// This completely disables Inventory Setups integration.
 		// Inventory Setups now uses core Bank Tags.
-		if (activeTag != null && activeTag.startsWith("_invSetup_")) return null;
+		if (activeTag != null && activeTag.startsWith("_invsetup_")) return null;
 
 		boolean isBankTag = activeTag != null && !activeTag.equals("tagtabs");
 		if (!isBankTag && !(inventorySetup != null && config.useWithInventorySetups())) {


### PR DESCRIPTION
Tested with latest inventory setup which changed the tag. The reason for this change is that Bank Tags operates entirely on lower case, and having the tag not be lowercase scares me. To be consistent i want to make it lowercase in case some change occurs where the inconsistency causes something to break or even worse, data loss.