### PR TITLE
Add right-click menu options for adding empty row and removing empty row

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -131,6 +131,8 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 	public static final String PREVIEW_AUTO_LAYOUT = "Preview auto layout";
 	public static final String DUPLICATE_ITEM = "Duplicate-item";
 	public static final String REMOVE_DUPLICATE_ITEM = "Remove-duplicate-item";
+	private static final String ADD_EMPTY_ROW = "Add empty row";
+	private static final String REMOVE_EMPTY_ROW = "Remove empty row";
 
 	public static final int BANK_ITEM_WIDTH = 36;
 	public static final int BANK_ITEM_HEIGHT = 32;
@@ -1156,6 +1158,8 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 
 		addFakeItemMenuEntries(menuEntryAdded);
 		addDuplicateItemMenuEntries(menuEntryAdded);
+		addRemoveRowMenuEntry(menuEntryAdded);
+		addNewRowMenuEntry(menuEntryAdded);
 	}
 
 	private void addBankTagTabMenuEntries()
@@ -1322,6 +1326,52 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		}
 	}
 
+	private void addNewRowMenuEntry(MenuEntryAdded menuEntryAdded)
+	{
+		if (!menuEntryAdded.getOption().equalsIgnoreCase("cancel")) return;
+
+		LayoutableThing layoutable = getCurrentLayoutableThing();
+		if (layoutable == null || !hasLayoutEnabled(layoutable)) return;
+
+		Layout layout = getBankOrder(layoutable);
+		if (layout == null) return;
+
+		int index = getIndexForMousePosition(true);
+		if (index == -1) return;
+
+		// Only allow on empty layout slots
+		if (layout.getItemAtIndex(index) != -1) return;
+
+		client.createMenuEntry(-1)
+				.setOption(ADD_EMPTY_ROW)
+				.setTarget("")
+				.setType(MenuAction.RUNELITE_OVERLAY)
+				.setParam0(index);
+	}
+
+	private void addRemoveRowMenuEntry(MenuEntryAdded menuEntryAdded)
+	{
+		if (!menuEntryAdded.getOption().equalsIgnoreCase("cancel")) return;
+
+		LayoutableThing layoutable = getCurrentLayoutableThing();
+		if (layoutable == null || !hasLayoutEnabled(layoutable)) return;
+
+		Layout layout = getBankOrder(layoutable);
+		if (layout == null) return;
+
+		int index = getIndexForMousePosition(true);
+		if (index == -1) return;
+
+		// Must be empty slot AND entire row must be empty
+		if (layout.getItemAtIndex(index) != -1) return;
+		if (!layout.isRowEmpty(index)) return;
+
+		client.createMenuEntry(-1)
+				.setOption(REMOVE_EMPTY_ROW)
+				.setType(MenuAction.RUNELITE_OVERLAY)
+				.setParam0(index);
+	}
+
 	/**
 	 * @return -1 if the mouse is not over a location where a bank item can be.
 	 */
@@ -1425,6 +1475,10 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 			duplicateItem(event.getParam0());
 		} else if (REMOVE_DUPLICATE_ITEM.equals(menuOption)) {
 			removeFromLayout(event.getParam0());
+		} else if (ADD_EMPTY_ROW.equals(menuOption)) {
+			addEmptyRow(event.getParam0());
+		} else if (REMOVE_EMPTY_ROW.equals(menuOption)) {
+			removeEmptyRow(event.getParam0());
 		} else {
 			consume = false;
 		}
@@ -1448,6 +1502,35 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		Layout layout = getBankOrder(layoutable);
 
 		layout.duplicateItem(clickedItemIndex, getIdForIndexInRealBank(clickedItemIndex));
+		saveLayout(layoutable, layout);
+
+		applyCustomBankTagItemPositions();
+	}
+
+	private void addEmptyRow(int index)
+	{
+		LayoutableThing layoutable = getCurrentLayoutableThing();
+		if (layoutable == null) return;
+
+		Layout layout = getBankOrder(layoutable);
+		if (layout == null) return;
+
+		layout.insertBlankRow(index);
+		saveLayout(layoutable, layout);
+
+		applyCustomBankTagItemPositions();
+	}
+	private void removeEmptyRow(int index)
+	{
+		LayoutableThing layoutable = getCurrentLayoutableThing();
+		if (layoutable == null) return;
+
+		Layout layout = getBankOrder(layoutable);
+		if (layout == null) return;
+
+		if (!layout.isRowEmpty(index)) return;
+
+		layout.removeBlankRow(index);
 		saveLayout(layoutable, layout);
 
 		applyCustomBankTagItemPositions();

--- a/src/main/java/com/banktaglayouts/Layout.java
+++ b/src/main/java/com/banktaglayouts/Layout.java
@@ -2,13 +2,7 @@ package com.banktaglayouts;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -198,5 +192,54 @@ public class Layout {
         }
 
         putItem(itemIdAtIndex, duplicatedItemIndex);
+    }
+
+    public void insertBlankRow(int startIndex)
+    {
+        int rowStart = (startIndex / 8) * 8;
+
+        // Move everything down by one row (iterate descending to avoid overwrites)
+        layoutMap.keySet().stream()
+                .sorted(Comparator.reverseOrder())
+                .forEach(index ->
+                {
+                    if (index >= rowStart)
+                    {
+                        int itemId = layoutMap.remove(index);
+                        layoutMap.put(index + 8, itemId);
+                    }
+                });
+    }
+
+    public void removeBlankRow(int index)
+    {
+        int rowStart = (index / 8) * 8;
+
+        layoutMap.keySet().stream()
+                .sorted(Comparator.naturalOrder())
+                .forEach(i ->
+                {
+                    if (i >= rowStart + 8)
+                    {
+                        int itemId = layoutMap.remove(i);
+                        layoutMap.put(i - 8, itemId);
+                    }
+                });
+    }
+
+
+    public boolean isRowEmpty(int index)
+    {
+        int rowStart = (index / 8) * 8;
+        int rowEnd = rowStart + 8;
+
+        for (int i = rowStart; i < rowEnd; i++)
+        {
+            if (layoutMap.containsKey(i))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/banktaglayouts/Layout.java
+++ b/src/main/java/com/banktaglayouts/Layout.java
@@ -196,9 +196,8 @@ public class Layout {
 
     public void insertBlankRow(int startIndex)
     {
-        int rowStart = (startIndex / 8) * 8;
+        int rowStart = ((startIndex / 8) + 1) * 8;
 
-        // Move everything down by one row (iterate descending to avoid overwrites)
         layoutMap.keySet().stream()
                 .sorted(Comparator.reverseOrder())
                 .forEach(index ->


### PR DESCRIPTION
This feature adds a right-click option for adding or removing empty rows when right-clicking an empty bank space.

https://github.com/user-attachments/assets/8f843e33-bd6c-4e3e-aaa5-1efdde0a6282

Instead of having to move every single item down one in order to organize my large mahogany hull parts, I can simply right click an empty bank space to move everything underneath it down one row.

The "remove empty row" option will only show if that entire row is empty. I couldn't really think of a clean way to handle items in a row that you're trying to remove.

This only works on the bank tag layouts mode, not runelite's or inventory setups. To my knowledge, this plugin is no longer integrated in with inventory setups right? I wasn't sure if I was able to add these menu options to inventory setups through this plugin, but that'd be great if I could.

This addition follows suit with all your current formatting and structure for creating menu entries. If you'd like the menu entries renamed to something you'd prefer, "Insert empty row", "Insert row" "Remove row" etc., or if you'd like me to add a config toggle, let me know.